### PR TITLE
task(homebrew): add source-built kongctl formula

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@1f8e202ffddf94def7f42f6fa3a482e821489f9c # 2026.07.10.1
 
       - name: Set up git
         uses: Homebrew/actions/git-user-config@master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,100 @@
+name: Homebrew
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out tap
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 2
+          persist-credentials: false
+
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@cced187498280712e078aaba62dc13a3e9cd80bf
+
+      - name: Trust tap
+        run: brew trust --tap kong/kongctl
+
+      - name: Check tap
+        run: |
+          brew style Formula/kongctl.rb Casks/kongctl.rb
+          brew readall --os=all --arch=all kong/kongctl
+          brew audit --new --formula kong/kongctl/kongctl
+
+  install:
+    name: Install (${{ matrix.name }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux
+            runner: ubuntu-latest
+          - name: macOS Apple Silicon
+            runner: macos-15
+          - name: macOS Intel
+            runner: macos-15-intel
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Check out tap
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@cced187498280712e078aaba62dc13a3e9cd80bf
+
+      - name: Trust tap
+        run: brew trust --tap kong/kongctl
+
+      - name: Test cask migration and fresh formula install
+        shell: bash
+        run: |
+          set -euo pipefail
+          brew install --cask kong/kongctl/kongctl
+          brew uninstall --cask kong/kongctl/kongctl
+          brew install --formula --build-from-source kong/kongctl/kongctl
+          brew test kong/kongctl/kongctl
+          kongctl version --full
+
+  upgrade:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out tap
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 2
+          persist-credentials: false
+
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@cced187498280712e078aaba62dc13a3e9cd80bf
+
+      - name: Trust tap
+        run: brew trust --tap kong/kongctl
+
+      - name: Test formula upgrade
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! git cat-file -e HEAD^:Formula/kongctl.rb 2>/dev/null; then
+            echo "No previous formula to upgrade from"
+            exit 0
+          fi
+
+          current_formula="$RUNNER_TEMP/kongctl-current.rb"
+          cp Formula/kongctl.rb "$current_formula"
+          git show HEAD^:Formula/kongctl.rb > Formula/kongctl.rb
+          brew install --formula --build-from-source kong/kongctl/kongctl
+          cp "$current_formula" Formula/kongctl.rb
+          brew upgrade --formula --build-from-source kong/kongctl/kongctl
+          brew test kong/kongctl/kongctl
+          kongctl version --full

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@1f8e202ffddf94def7f42f6fa3a482e821489f9c # 2026.07.10.1
 
       - name: Cache Homebrew Bundler RubyGems
         uses: actions/cache@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,8 +9,9 @@ on:
 jobs:
   test-bot:
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-13, macos-14]
+        os: [ubuntu-24.04, macos-15, macos-15-intel]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew

--- a/Casks/kongctl.rb
+++ b/Casks/kongctl.rb
@@ -31,7 +31,19 @@ cask "kongctl" do
     skip "Auto-generated on release."
   end
 
+  deprecate! date:                "2026-08-31",
+             because:             "is superseded by the source-built formula",
+             replacement_formula: "kong/kongctl/kongctl"
+
   binary "kongctl"
+
+  caveats <<~EOS
+    The kongctl cask is deprecated but will continue receiving releases during
+    the migration period. Migrate to the source-built formula:
+
+      brew uninstall --cask kongctl
+      brew install --formula kong/kongctl/kongctl
+  EOS
 
   # No zap stanza required
 end

--- a/Formula/kongctl.rb
+++ b/Formula/kongctl.rb
@@ -1,0 +1,27 @@
+class Kongctl < Formula
+  desc "Developer CLI for Kong"
+  homepage "https://github.com/Kong/kongctl"
+  url "https://github.com/Kong/kongctl/archive/refs/tags/v1.14.0.tar.gz"
+  sha256 "7f92ebe97b355f239cc9d2cf11159c001b21d322cd85d0fda36ffcfb207c8a43"
+  license "Apache-2.0"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = %W[
+      -X main.version=#{version}
+      -X main.commit=b3808868
+      -X main.date=2026-08-31T15:58:41Z
+    ]
+
+    ENV["CGO_ENABLED"] = "0"
+    system "go", "build", *std_go_args(ldflags:)
+  end
+
+  test do
+    output = shell_output("#{bin}/kongctl version --full")
+    assert_match version.to_s, output
+    assert_match "b3808868", output
+    assert_match "__kongctl_debug", shell_output("#{bin}/kongctl completion bash")
+  end
+end

--- a/README.md
+++ b/README.md
@@ -1,21 +1,32 @@
 # Kong kongctl
 
-## How do I install this cask?
+## Installation
 
-`brew install --cask kong/kongctl/kongctl`
+Install the source-built formula:
 
-Or `brew tap kong/kongctl` and then `brew install --cask kongctl`.
+```shell
+brew install --formula kong/kongctl/kongctl
+```
 
 Or, in a [`brew bundle`](https://github.com/Homebrew/homebrew-bundle) `Brewfile`:
 
 ```ruby
 tap "kong/kongctl"
-cask "kongctl"
+brew "kongctl"
 ```
 
-## Notes
+## Migrating from the cask
 
-The legacy Homebrew formula has been disabled. If you previously used `brew install kongctl`, switch to the cask commands above.
+The cask is deprecated but will continue receiving releases until Homebrew
+disables it on August 31, 2027. Existing cask users can migrate with:
+
+```shell
+brew uninstall --cask kongctl
+brew install --formula kong/kongctl/kongctl
+```
+
+Ordinary cask uninstall preserves kongctl configuration and authentication
+data. Do not use `--zap` for this migration.
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

- add a source-built `kongctl` formula while keeping the cask current during migration
- deprecate the cask with Homebrew migration guidance and an August 31, 2027 disable date
- add tap CI for audits, source installs, cask migration, and formula upgrades

This prepares the tap for the release automation tracked by Kong/kongctl#2009. This PR should merge before the companion kongctl PR.

## Validation

- `brew style Formula/kongctl.rb Casks/kongctl.rb`
- `brew readall --os=all --arch=all kong/kongctl`
- `brew audit --new --formula kong/kongctl/kongctl`
- Linux cask install, uninstall, source formula build, and `brew test`
- `actionlint .github/workflows/test.yml`

The PR workflow provides the remaining native macOS Apple Silicon and Intel validation.