### PR TITLE
task(homebrew): set six-month cask migration window

### DIFF
--- a/Casks/kongctl.rb
+++ b/Casks/kongctl.rb
@@ -31,15 +31,16 @@ cask "kongctl" do
     skip "Auto-generated on release."
   end
 
-  deprecate! date:                "2026-08-31",
-             because:             "is superseded by the source-built formula",
-             replacement_formula: "kong/kongctl/kongctl"
+  disable! date:                "2026-11-30",
+           because:             "is superseded by the formula; first run `brew uninstall --cask kongctl`",
+           replacement_formula: "kong/kongctl/kongctl"
 
   binary "kongctl"
 
   caveats <<~EOS
-    The kongctl cask is deprecated but will continue receiving releases during
-    the migration period. Migrate to the source-built formula:
+    The kongctl cask is deprecated and will continue receiving releases until
+    Homebrew disables it on November 30, 2026. Migrate to the source-built
+    formula:
 
       brew uninstall --cask kongctl
       brew install --formula kong/kongctl/kongctl

--- a/Casks/kongctl.rb
+++ b/Casks/kongctl.rb
@@ -31,7 +31,7 @@ cask "kongctl" do
     skip "Auto-generated on release."
   end
 
-  disable! date:                "2026-11-30",
+  disable! date:                "2027-02-28",
            because:             "is superseded by the formula; first run `brew uninstall --cask kongctl`",
            replacement_formula: "kong/kongctl/kongctl"
 
@@ -39,7 +39,7 @@ cask "kongctl" do
 
   caveats <<~EOS
     The kongctl cask is deprecated and will continue receiving releases until
-    Homebrew disables it on November 30, 2026. Migrate to the source-built
+    Homebrew disables it on February 28, 2027. Migrate to the source-built
     formula:
 
       brew uninstall --cask kongctl

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ brew "kongctl"
 ## Migrating from the cask
 
 The cask is deprecated but will continue receiving releases until Homebrew
-disables it on August 31, 2027. Existing cask users can migrate with:
+disables it on November 30, 2026. Existing cask users can migrate with:
 
 ```shell
 brew uninstall --cask kongctl

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ brew "kongctl"
 ## Migrating from the cask
 
 The cask is deprecated but will continue receiving releases until Homebrew
-disables it on November 30, 2026. Existing cask users can migrate with:
+disables it on February 28, 2027. Existing cask users can migrate with:
 
 ```shell
 brew uninstall --cask kongctl


### PR DESCRIPTION
## Summary

- schedule cask disablement for February 28, 2027, six months after deprecation began
- include the required cask uninstall command in the early Homebrew warning
- retain the complete uninstall-and-formula-install sequence in the post-install caveats

This is the tap-side follow-up to Kong/kongctl#2036.

## Validation

- Ruby syntax checks for the formula and cask
- `actionlint` for the tap workflows
- `git diff --check`
- manual Apple Silicon validation of the published v1.14.0 cask-to-formula migration

The PR Homebrew jobs validate style, audit, and native installation behavior before merge.