### PR TITLE
task(homebrew): keep cask supported alongside formula

### DIFF
--- a/Casks/kongctl.rb
+++ b/Casks/kongctl.rb
@@ -31,20 +31,7 @@ cask "kongctl" do
     skip "Auto-generated on release."
   end
 
-  disable! date:                "2027-02-28",
-           because:             "is superseded by the formula; first run `brew uninstall --cask kongctl`",
-           replacement_formula: "kong/kongctl/kongctl"
-
   binary "kongctl"
-
-  caveats <<~EOS
-    The kongctl cask is deprecated and will continue receiving releases until
-    Homebrew disables it on February 28, 2027. Migrate to the source-built
-    formula:
-
-      brew uninstall --cask kongctl
-      brew install --formula kong/kongctl/kongctl
-  EOS
 
   # No zap stanza required
 end

--- a/README.md
+++ b/README.md
@@ -2,7 +2,14 @@
 
 ## Installation
 
-Install the source-built formula:
+Install the prebuilt cask:
+
+```shell
+brew install --cask kong/kongctl/kongctl
+```
+
+Alternatively, install the source-built formula. Homebrew installs Go as a
+build dependency when it builds the formula:
 
 ```shell
 brew install --formula kong/kongctl/kongctl
@@ -14,19 +21,6 @@ Or, in a [`brew bundle`](https://github.com/Homebrew/homebrew-bundle) `Brewfile`
 tap "kong/kongctl"
 brew "kongctl"
 ```
-
-## Migrating from the cask
-
-The cask is deprecated but will continue receiving releases until Homebrew
-disables it on February 28, 2027. Existing cask users can migrate with:
-
-```shell
-brew uninstall --cask kongctl
-brew install --formula kong/kongctl/kongctl
-```
-
-Ordinary cask uninstall preserves kongctl configuration and authentication
-data. Do not use `--zap` for this migration.
 
 ## Documentation
 


### PR DESCRIPTION
## Description

Removes the scheduled cask disablement and migration warnings while retaining
both supported Homebrew installation methods:

- the cask installs the prebuilt release archive;
- the formula builds from source and uses Go as a build dependency.

The README now documents both choices without directing existing cask users to
migrate.

Related to Kong/kongctl#2009 and Kong/kongctl#2036.

## Validation

- `ruby -c Casks/kongctl.rb`
- `ruby -c Formula/kongctl.rb`
- `git diff --check`