### PR TITLE
task(homebrew): publish formula bottles

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,38 +1,96 @@
 name: brew pr-pull
+run-name: Publish bottles for PR #${{ inputs.pull_request }}
 
 on:
-  pull_request_target:
-    types:
-      - labeled
+  workflow_dispatch:
+    inputs:
+      pull_request:
+        description: Pull request number
+        required: true
+        type: number
+      head_sha:
+        description: Expected pull request head commit SHA
+        required: true
+        type: string
+
+permissions: {}
+
+defaults:
+  run:
+    shell: bash -xeuo pipefail {0}
 
 jobs:
   pr-pull:
-    if: contains(github.event.pull_request.labels.*.name, 'pr-pull')
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
+      actions: read
+      attestations: write
+      checks: read
       contents: write
+      id-token: write
+      issues: read
+      packages: write
       pull-requests: write
     steps:
+      - name: Validate release pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ inputs.head_sha }}
+          PULL_REQUEST: ${{ inputs.pull_request }}
+        run: |
+          pr=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PULL_REQUEST")
+          actual_sha=$(jq -r '.head.sha' <<< "$pr")
+          base=$(jq -r '.base.ref' <<< "$pr")
+          branch=$(jq -r '.head.ref' <<< "$pr")
+          head_repo=$(jq -r '.head.repo.full_name' <<< "$pr")
+          state=$(jq -r '.state' <<< "$pr")
+
+          [[ "$actual_sha" == "$HEAD_SHA" ]]
+          [[ "$base" == "main" ]]
+          [[ "$branch" == release/kongctl-* ]]
+          [[ "$head_repo" == "$GITHUB_REPOSITORY" ]]
+          [[ "$state" == "open" ]]
+
+          changed_files=$(gh api --paginate \
+            "repos/$GITHUB_REPOSITORY/pulls/$PULL_REQUEST/files" \
+            --jq '.[].filename')
+          [[ "$changed_files" == "Formula/kongctl.rb" ]]
+
+          gh pr checks "$PULL_REQUEST" \
+            --repo "$GITHUB_REPOSITORY" \
+            --fail-fast
+
       - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@1f8e202ffddf94def7f42f6fa3a482e821489f9c # 2026.07.10.1
+        uses: Homebrew/actions/setup-homebrew@3cdb78d0f62ad29dd32de765782654f4eedea607 # 2026.08.31.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up git
-        uses: Homebrew/actions/git-user-config@master
+        id: git_setup
+        uses: Homebrew/actions/git-user-config@3cdb78d0f62ad29dd32de765782654f4eedea607 # 2026.08.31.1
 
-      - name: Pull bottles
+      - name: Pull and publish bottles
+        id: pull_bottles
         env:
-          HOMEBREW_GITHUB_API_TOKEN: ${{ github.token }}
-          PULL_REQUEST: ${{ github.event.pull_request.number }}
-        run: brew pr-pull --debug --tap="$GITHUB_REPOSITORY" "$PULL_REQUEST"
+          HEAD_SHA: ${{ inputs.head_sha }}
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_GITHUB_PACKAGES_USER: ${{ github.repository_owner }}
+          HOMEBREW_GIT_COMMITTER_EMAIL: ${{ steps.git_setup.outputs.email }}
+          HOMEBREW_GIT_COMMITTER_NAME: ${{ steps.git_setup.outputs.name }}
+          PULL_REQUEST: ${{ inputs.pull_request }}
+        run: >-
+          brew pr-pull --debug --retain-bottle-dir
+          --tap="$GITHUB_REPOSITORY" --head-sha="$HEAD_SHA"
+          "$PULL_REQUEST"
+
+      - name: Generate build provenance
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-path: "${{ steps.pull_bottles.outputs.bottle_path }}/*.tar.gz"
 
       - name: Push commits
-        uses: Homebrew/actions/git-try-push@master
+        uses: Homebrew/actions/git-try-push@3cdb78d0f62ad29dd32de765782654f4eedea607 # 2026.08.31.1
         with:
-          token: ${{ github.token }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           branch: main
-
-      - name: Delete branch
-        if: github.event.pull_request.head.repo.fork == false
-        env:
-          BRANCH: ${{ github.event.pull_request.head.ref }}
-        run: git push --delete origin "$BRANCH"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,6 +43,24 @@ jobs:
 
       - run: brew test-bot --only-setup
 
+      # Homebrew's Intel ShellCheck dependency needs GMP from source, whose
+      # download servers are unreliable from GitHub runners. Keep this version
+      # aligned with homebrew/core so brew style accepts the executable on PATH.
+      - name: Install ShellCheck binary on Intel macOS
+        if: matrix.os == 'macos-15-intel'
+        run: |
+          shellcheck_dir=$(mktemp -d "$RUNNER_TEMP/shellcheck.XXXXXX")
+          archive="$shellcheck_dir/shellcheck.tar.gz"
+          curl --fail --location --retry 3 --connect-timeout 15 --max-time 120 \
+            --output "$archive" \
+            https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.darwin.x86_64.tar.gz
+          printf '%s  %s\n' \
+            c2c15e08df0e8fbc374c335b230a7ee958c313fa5714817a59aa59f1aa594f51 \
+            "$archive" | shasum -a 256 --check
+          tar -xzf "$archive" -C "$shellcheck_dir"
+          "$shellcheck_dir/shellcheck-v0.11.0/shellcheck" --version
+          echo "$shellcheck_dir/shellcheck-v0.11.0" >> "$GITHUB_PATH"
+
       - run: brew test-bot --only-tap-syntax
 
       - name: Authorize GitHub Packages

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,12 @@ on:
       - main
   pull_request:
 
+permissions: {}
+
+defaults:
+  run:
+    shell: bash -xeuo pipefail {0}
+
 jobs:
   test-bot:
     strategy:
@@ -13,13 +19,21 @@ jobs:
       matrix:
         os: [ubuntu-24.04, macos-15, macos-15-intel]
     runs-on: ${{ matrix.os }}
+    permissions:
+      actions: read
+      checks: read
+      contents: read
+      packages: read
+      pull-requests: read
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@1f8e202ffddf94def7f42f6fa3a482e821489f9c # 2026.07.10.1
+        uses: Homebrew/actions/setup-homebrew@3cdb78d0f62ad29dd32de765782654f4eedea607 # 2026.08.31.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Homebrew Bundler RubyGems
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
           key: ${{ matrix.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
@@ -31,12 +45,27 @@ jobs:
 
       - run: brew test-bot --only-tap-syntax
 
-      - run: brew test-bot --only-formulae
+      - name: Authorize GitHub Packages
+        id: packages
         if: github.event_name == 'pull_request'
+        env:
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          token=$(printf '%s' "$TOKEN" | base64 | tr -d '\n')
+          echo "::add-mask::$token"
+          echo "token=$token" >> "$GITHUB_OUTPUT"
+
+      - name: Test formula and build bottle
+        if: github.event_name == 'pull_request'
+        env:
+          HOMEBREW_DOCKER_REGISTRY_TOKEN: ${{ steps.packages.outputs.token }}
+        run: >-
+          brew test-bot --only-formulae
+          --root-url=https://ghcr.io/v2/kong/kongctl
 
       - name: Upload bottles as artifact
         if: always() && github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bottles_${{ matrix.os }}
           path: '*.bottle.*'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,6 +65,24 @@ jobs:
           ln -s "$shellcheck_dir/shellcheck-v0.11.0/shellcheck" "$shellcheck_bin"
           "$shellcheck_bin" --version
 
+      # Installing actionlint through Homebrew pulls in its ShellCheck formula
+      # dependency even when an external ShellCheck binary is already on PATH.
+      - name: Install actionlint binary on Intel macOS
+        if: matrix.os == 'macos-15-intel'
+        run: |
+          actionlint_dir=$(mktemp -d "$RUNNER_TEMP/actionlint.XXXXXX")
+          archive="$actionlint_dir/actionlint.tar.gz"
+          curl --fail --location --retry 3 --connect-timeout 15 --max-time 120 \
+            --output "$archive" \
+            https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_darwin_amd64.tar.gz
+          printf '%s  %s\n' \
+            5b44c3bc2255115c9b69e30efc0fecdf498fdb63c5d58e17084fd5f16324c644 \
+            "$archive" | shasum -a 256 --check
+          tar -xzf "$archive" -C "$actionlint_dir" actionlint
+          actionlint_bin="$(brew --prefix)/bin/actionlint"
+          ln -s "$actionlint_dir/actionlint" "$actionlint_bin"
+          "$actionlint_bin" -version
+
       - run: brew test-bot --only-tap-syntax --verbose
         timeout-minutes: 10
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,9 +59,14 @@ jobs:
             "$archive" | shasum -a 256 --check
           tar -xzf "$archive" -C "$shellcheck_dir"
           "$shellcheck_dir/shellcheck-v0.11.0/shellcheck" --version
-          echo "$shellcheck_dir/shellcheck-v0.11.0" >> "$GITHUB_PATH"
+          # test-bot rebuilds PATH for nested brew commands. Its explicit
+          # prefix/bin survives that reset, unlike a GITHUB_PATH addition.
+          shellcheck_bin="$(brew --prefix)/bin/shellcheck"
+          ln -s "$shellcheck_dir/shellcheck-v0.11.0/shellcheck" "$shellcheck_bin"
+          "$shellcheck_bin" --version
 
-      - run: brew test-bot --only-tap-syntax
+      - run: brew test-bot --only-tap-syntax --verbose
+        timeout-minutes: 10
 
       - name: Authorize GitHub Packages
         id: packages

--- a/README.md
+++ b/README.md
@@ -8,12 +8,15 @@ Install the prebuilt cask:
 brew install --cask kong/kongctl/kongctl
 ```
 
-Alternatively, install the source-built formula. Homebrew installs Go as a
-build dependency when it builds the formula:
+Alternatively, install the formula. Homebrew downloads a prebuilt bottle for
+supported macOS and Linux platforms, so Go is not needed for a normal install:
 
 ```shell
 brew install --formula kong/kongctl/kongctl
 ```
+
+If a bottle is unavailable or `--build-from-source` is requested, Homebrew
+builds the formula locally and installs Go as a build dependency.
 
 Or, in a [`brew bundle`](https://github.com/Homebrew/homebrew-bundle) `Brewfile`:
 


### PR DESCRIPTION
## Summary

- build Linux, Apple Silicon macOS, and Intel macOS bottles with Homebrew test-bot
- publish bottles to GitHub Packages through the standard pr-pull lifecycle
- require an expected PR head SHA and accept only formula-only release PRs
- document that normal formula installs use bottles without requiring Go

## Release behavior

This PR installs the tap-side infrastructure. Future kongctl releases will continue pushing the existing cask directly to main, then open a formula-only PR. Once its bottle checks pass, the kongctl release workflow dispatches the publisher, which writes the bottle metadata to main and closes the formula PR automatically.

This PR does not change the current cask or formula definitions and does not publish a bottle for kongctl 1.15.0.

## Validation

- actionlint .github/workflows/*.yml
- git diff --check

The native Homebrew jobs in this PR provide the platform-level validation.