### PR TITLE
kongctl: bootstrap bottles for 1.15.0

### DIFF
--- a/Formula/kongctl.rb
+++ b/Formula/kongctl.rb
@@ -23,5 +23,6 @@ class Kongctl < Formula
     assert_match version.to_s, output
     assert_match "86e156e0", output
     assert_match "__kongctl_debug", shell_output("#{bin}/kongctl completion bash")
+    assert_match "#compdef kongctl", shell_output("#{bin}/kongctl completion zsh")
   end
 end


### PR DESCRIPTION
## Summary

Bootstrap native Homebrew bottles for the existing kongctl 1.15.0 release.

- Add a zsh completion smoke test to exercise the installed executable and trigger the formula-only bottle build pipeline.
- Keep the source version, checksum, build recipe, and cask unchanged.
- Build Linux x86_64, macOS Apple Silicon, and macOS Intel bottles using the workflows merged in #9.

## Publication and verification

All three native bottle jobs now pass, including local bottle installation and formula tests. All three downloaded archives match their JSON SHA-256 metadata. The current branch temporarily includes the workflow fix from #11 to exercise Intel bottling; merge #11 first, then synchronize this branch with main so this PR is formula-only again before publication.

Do not manually merge this PR. After all checks pass and all three bottle artifacts are verified, dispatch `publish.yml` on `main` with this PR number and its exact tested head SHA. The publisher should upload bottles to GHCR and update the formula on main with bottle metadata.

Then verify anonymous bottle downloads and installation without Go. This is the end-to-end rollout checkpoint before enabling automated release orchestration in Kong/kongctl#2073.

## Local validation

- Ruby syntax validation
- `git diff --check`
