### PR TITLE
ci: build Intel bottles with source dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -116,7 +116,7 @@ jobs:
           brew install --formula --build-bottle kong/kongctl/kongctl
           brew bottle --json --root-url=https://ghcr.io/v2/kong/kongctl kong/kongctl/kongctl
           shopt -s nullglob
-          bottles=(kongctl--*.bottle.tar.gz)
+          bottles=(kongctl--*.bottle*.tar.gz)
           [[ ${#bottles[@]} -eq 1 ]]
           brew uninstall --formula kong/kongctl/kongctl
           brew install --formula "./${bottles[0]}"
@@ -130,7 +130,7 @@ jobs:
           contains(steps.bottles.outputs.testing_formulae, 'kong/kongctl/kongctl')
         run: |
           shopt -s nullglob
-          bottles=(kongctl--*.bottle.tar.gz)
+          bottles=(kongctl--*.bottle*.tar.gz)
           metadata=(kongctl--*.bottle.json)
           [[ ${#bottles[@]} -eq 1 ]]
           [[ ${#metadata[@]} -eq 1 ]]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -97,12 +97,42 @@ jobs:
           echo "token=$token" >> "$GITHUB_OUTPUT"
 
       - name: Test formula and build bottle
+        id: bottles
         if: github.event_name == 'pull_request'
         env:
           HOMEBREW_DOCKER_REGISTRY_TOKEN: ${{ steps.packages.outputs.token }}
         run: >-
           brew test-bot --only-formulae
           --root-url=https://ghcr.io/v2/kong/kongctl
+
+      # test-bot skips Intel builds when Go has no compatible Homebrew bottle.
+      # The build dependency can still be installed from source by Homebrew.
+      - name: Build and test Intel bottle with source dependencies
+        if: >-
+          github.event_name == 'pull_request' && matrix.os == 'macos-15-intel' &&
+          steps.bottles.outputs.skipped_or_failed_formulae == 'kong/kongctl/kongctl'
+        run: |
+          brew install --formula --build-bottle kong/kongctl/kongctl
+          brew bottle --json --root-url=https://ghcr.io/v2/kong/kongctl kong/kongctl/kongctl
+          shopt -s nullglob
+          bottles=(kongctl--*.bottle.tar.gz)
+          [[ ${#bottles[@]} -eq 1 ]]
+          brew uninstall --formula kong/kongctl/kongctl
+          brew install --formula "./${bottles[0]}"
+          brew linkage --test kong/kongctl/kongctl
+          brew test kong/kongctl/kongctl
+          kongctl version --full
+
+      - name: Require bottle artifacts for changed formula
+        if: >-
+          github.event_name == 'pull_request' &&
+          contains(steps.bottles.outputs.testing_formulae, 'kong/kongctl/kongctl')
+        run: |
+          shopt -s nullglob
+          bottles=(kongctl--*.bottle.tar.gz)
+          metadata=(kongctl--*.bottle.json)
+          [[ ${#bottles[@]} -eq 1 ]]
+          [[ ${#metadata[@]} -eq 1 ]]
 
       - name: Upload bottles as artifact
         if: always() && github.event_name == 'pull_request'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -112,6 +112,7 @@ jobs:
           github.event_name == 'pull_request' && matrix.os == 'macos-15-intel' &&
           steps.bottles.outputs.skipped_or_failed_formulae == 'kong/kongctl/kongctl'
         run: |
+          brew install --formula --only-dependencies --build-from-source kong/kongctl/kongctl
           brew install --formula --build-bottle kong/kongctl/kongctl
           brew bottle --json --root-url=https://ghcr.io/v2/kong/kongctl kong/kongctl/kongctl
           shopt -s nullglob

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -119,7 +119,8 @@ jobs:
           bottles=(kongctl--*.bottle*.tar.gz)
           [[ ${#bottles[@]} -eq 1 ]]
           brew uninstall --formula kong/kongctl/kongctl
-          brew install --formula "./${bottles[0]}"
+          # Like test-bot, enable developer mode for this local archive install.
+          HOMEBREW_DEVELOPER=1 brew install --formula "./${bottles[0]}"
           brew linkage --test kong/kongctl/kongctl
           brew test kong/kongctl/kongctl
           kongctl version --full


### PR DESCRIPTION
## Summary

The real bottle bootstrap in #10 exposed an Intel-only skip: test-bot exits successfully without producing a kongctl bottle because its Go build dependency has no compatible Homebrew bottle.

- When test-bot skips kongctl on Intel, use Homebrew's native build-bottle commands, allowing Homebrew to build dependencies from source.
- Reinstall the generated local bottle and run linkage and formula smoke tests.
- Require a bottle archive and JSON metadata whenever kongctl is selected for testing, preventing silently incomplete publication.
- No cask or formula definition changes.

## Validation

- `actionlint .github/workflows/tests.yml`
- `git diff --check`
- The same workflow change is also tested with the formula change in #10 to exercise actual bottle generation.

Merge this workflow fix before publishing #10; the publisher requires a formula-only diff.
