### PR TITLE
ci: fix publisher check validation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,8 +57,7 @@ jobs:
           [[ "$changed_files" == "Formula/kongctl.rb" ]]
 
           gh pr checks "$PULL_REQUEST" \
-            --repo "$GITHUB_REPOSITORY" \
-            --fail-fast
+            --repo "$GITHUB_REPOSITORY"
 
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@3cdb78d0f62ad29dd32de765782654f4eedea607 # 2026.08.31.1


### PR DESCRIPTION
## Summary

Remove `--fail-fast` from the publisher's one-shot `gh pr checks` validation. GitHub CLI only accepts that flag with `--watch`, so the first publication attempt stopped before uploading bottles or changing main.

The one-shot check still exits nonzero for failed or pending checks. All existing exact-SHA, same-repository, release-branch, and formula-only guards remain unchanged.

## Validation

- `actionlint .github/workflows/publish.yml`
- `git diff --check`
- Ran the corrected command against bootstrap PR #10: all 11 checks passed, exit status 0.

After merging, dispatch `publish.yml` again on main for PR #10 at `922b8eaade33bc497ed36c242d5268f249f83cb2`. Its existing tested bottle artifacts can be reused; no formula or cask changes are needed.

Failed publication run: https://github.com/Kong/homebrew-kongctl/actions/runs/33992814747
