### PR TITLE
ci: fix duplicate publisher authentication headers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,5 +91,7 @@ jobs:
       - name: Push commits
         uses: Homebrew/actions/git-try-push@3cdb78d0f62ad29dd32de765782654f4eedea607 # 2026.08.31.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # setup-homebrew already supplies Git authentication globally.
+          # Passing token here adds a second Authorization header and fails.
           branch: main
+          tries: 3


### PR DESCRIPTION
## Summary

The bootstrap publisher successfully uploaded all three bottles to GHCR and generated provenance, but its final Git push failed with `Duplicate header: "Authorization"` (HTTP 400).

The pinned setup-homebrew action configures Git's Authorization extraheader globally. Passing `token` to git-try-push also configures that same extraheader locally. Git sends both headers.

- Reuse setup-homebrew's existing authentication by omitting the optional push-action token.
- Limit push retries to three so a deterministic push error does not cause a long retry loop.
- Keep the existing write permissions, non-force push, and publication validation unchanged.

## Validation

- Inspected the pinned implementations of both Homebrew actions: setup sets the global header; git-try-push only adds a local header when token is provided.
- `actionlint .github/workflows/publish.yml`
- `git diff --check`
- Anonymous GHCR manifest access confirms all three platform bottles exist at `kong/kongctl/kongctl:1.15.0-1`.

Run: https://github.com/Kong/homebrew-kongctl/actions/runs/33994615072 (stopped after repeated push failures; uploads and provenance succeeded).

After merging, dispatch publish.yml on main for PR #10 with head SHA `e7d32bf84e6c8aee880b3599d1d8c4310e5cc1ba`. Leave #10 open; it now has a clean single-formula-commit history, and its tested artifacts can be reused.
