### PR TITLE
ci: recover existing bottle uploads safely

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,10 @@ on:
         description: Expected pull request head commit SHA
         required: true
         type: string
+      reuse_uploaded_bottles:
+        description: Recover a failed metadata push using verified existing public bottles
+        default: false
+        type: boolean
 
 permissions: {}
 
@@ -68,6 +72,13 @@ jobs:
         id: git_setup
         uses: Homebrew/actions/git-user-config@3cdb78d0f62ad29dd32de765782654f4eedea607 # 2026.08.31.1
 
+      - name: Use tap main for publication
+        run: |
+          # A workflow can be dispatched from a maintenance branch. Never
+          # include that branch's workflow changes in the published commits.
+          git fetch origin main
+          git checkout -B main FETCH_HEAD
+
       - name: Pull and publish bottles
         id: pull_bottles
         env:
@@ -78,10 +89,50 @@ jobs:
           HOMEBREW_GIT_COMMITTER_EMAIL: ${{ steps.git_setup.outputs.email }}
           HOMEBREW_GIT_COMMITTER_NAME: ${{ steps.git_setup.outputs.name }}
           PULL_REQUEST: ${{ inputs.pull_request }}
-        run: >-
-          brew pr-pull --debug --retain-bottle-dir
-          --tap="$GITHUB_REPOSITORY" --head-sha="$HEAD_SHA"
-          "$PULL_REQUEST"
+          REUSE_UPLOADED_BOTTLES: ${{ inputs.reuse_uploaded_bottles }}
+        run: |
+          args=(--debug --retain-bottle-dir --tap="$GITHUB_REPOSITORY" --head-sha="$HEAD_SHA")
+          if [[ "$REUSE_UPLOADED_BOTTLES" == true ]]; then
+            args+=(--no-upload)
+          fi
+          brew pr-pull "${args[@]}" "$PULL_REQUEST"
+
+      - name: Verify existing public bottles and recover metadata
+        if: inputs.reuse_uploaded_bottles
+        env:
+          BOTTLE_DIR: ${{ steps.pull_bottles.outputs.bottle_path }}
+        run: |
+          shopt -s nullglob
+          metadata=("$BOTTLE_DIR"/*.bottle.json)
+          [[ ${#metadata[@]} -eq 3 ]]
+          expected_version=$(brew info --json=v2 --formula kong/kongctl/kongctl | jq -er '.formulae[0].versions.stable')
+          # Obtain an anonymous pull token; never use repository credentials
+          # to prove that ordinary users can download these bottles.
+          set +x
+          registry_token=$(curl --fail --silent --show-error --retry 3 --max-time 60 \
+            'https://ghcr.io/token?service=ghcr.io&scope=repository:kong/kongctl/kongctl:pull' | jq -er .token)
+          for json in "${metadata[@]}"; do
+            jq -e --arg version "$expected_version" '
+              keys == ["kong/kongctl/kongctl"] and
+              (.[] | .formula.pkg_version == $version and
+                .bottle.root_url == "https://ghcr.io/v2/kong/kongctl" and
+                (.bottle.tags | length == 1))
+            ' "$json" >/dev/null
+            digest=$(jq -er '.[] .bottle.tags[] .sha256' "$json")
+            filename=$(jq -er '.[] .bottle.tags[] .local_filename' "$json")
+            [[ "$digest" =~ ^[0-9a-f]{64}$ ]]
+            [[ "$filename" == "$(basename "$filename")" ]]
+            printf '%s  %s\n' "$digest" "$BOTTLE_DIR/$filename" | sha256sum --check
+            actual=$(curl --fail --silent --show-error --location --retry 3 --max-time 180 \
+              -H "Authorization: Bearer $registry_token" \
+              "https://ghcr.io/v2/kong/kongctl/kongctl/blobs/sha256:$digest" | sha256sum)
+            [[ "${actual%% *}" == "$digest" ]]
+          done
+          unset registry_token
+          set -x
+          jq -s -e '[.[] | .[] .bottle.tags | keys[]] | sort == ["arm64_sequoia", "sequoia", "x86_64_linux"]' "${metadata[@]}"
+          brew bottle --merge --write "${metadata[@]}"
+          brew audit --formula kong/kongctl/kongctl
 
       - name: Generate build provenance
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2

--- a/.github/workflows/verify-bottles.yml
+++ b/.github/workflows/verify-bottles.yml
@@ -1,0 +1,58 @@
+name: Verify published bottles
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/workflows/verify-bottles.yml
+
+permissions:
+  contents: read
+
+jobs:
+  install:
+    name: Published bottle (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, macos-15, macos-15-intel]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    steps:
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@3cdb78d0f62ad29dd32de765782654f4eedea607 # 2026.08.31.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Use the publicly released formula
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch origin main
+          git checkout --detach FETCH_HEAD
+          brew trust --tap kong/kongctl
+
+      - name: Install a public bottle without a Homebrew Go dependency
+        shell: bash
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
+        run: |
+          set -euo pipefail
+          # These are disposable runners; remove preinstalled Homebrew Go
+          # formulae so the test proves they are not needed or reinstalled.
+          while IFS= read -r formula; do
+            case "$formula" in
+              go|go@*) brew uninstall --formula --force --ignore-dependencies "$formula" ;;
+            esac
+          done < <(brew list --formula)
+          unset HOMEBREW_GITHUB_API_TOKEN HOMEBREW_GITHUB_PACKAGES_TOKEN
+          unset HOMEBREW_DOCKER_REGISTRY_TOKEN GITHUB_TOKEN GH_TOKEN
+          brew install --formula --force-bottle kong/kongctl/kongctl
+          brew info --json=v2 --formula kong/kongctl/kongctl |
+            jq -e '.formulae[0].installed | length == 1 and .[0].poured_from_bottle == true'
+          brew test kong/kongctl/kongctl
+          kongctl version --full
+          if brew list --formula | grep -E '^go(@.*)?$'; then
+            echo '::error::Bottle installation unexpectedly installed Go'
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Add an explicit recovery mode for a bottle upload that succeeded before the formula metadata push failed. Homebrew refuses to overwrite an existing bottle tag on a normal retry.

- Default publication behavior is unchanged.
- Recovery downloads the exact tested PR artifacts without uploading.
- Verify the formula version, registry root, three expected platforms, local archive checksums, and anonymous downloads of every public bottle by SHA-256.
- Only after verification, merge bottle metadata with Homebrew and run the formula audit.
- Generate provenance and push normally, using the corrected authentication from #13.
- Explicitly base publication on tap main, even when the workflow is dispatched from a maintenance branch. This prevents publishing unmerged workflow changes alongside formula metadata.
- Add a manually runnable published-bottle verification workflow, also run when that workflow changes in a PR. It checks public-main formula installation on Linux, Apple Silicon, and Intel without a Homebrew Go dependency.

## Validation

- `actionlint .github/workflows/publish.yml`
- `git diff --check`
- End-to-end recovery succeeded: https://github.com/Kong/homebrew-kongctl/actions/runs/33995957588
- All three public bottle downloads matched their tested SHA-256 checksums; the formula metadata reached main and #10 closed automatically.
- Fresh-runner public bottle installation passed on all three platforms, with poured-from-bottle receipts and no Homebrew Go dependency: https://github.com/Kong/homebrew-kongctl/actions/runs/33996085737

No cask changes, token changes, registry deletions, or registry overwrites.
