### PR TITLE
task(release): consume upstream binaries and publish metadata only

### DIFF
--- a/.github/kongctl-release-protocol.json
+++ b/.github/kongctl-release-protocol.json
@@ -1,0 +1,6 @@
+{
+  "schema": 1,
+  "bottle_producer": "Kong/kongctl",
+  "formula_install": "upstream-binary",
+  "publisher": "metadata-only"
+}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,148 +1,58 @@
-name: brew pr-pull
-run-name: Publish bottles for PR #${{ inputs.pull_request }}
+name: Publish upstream formula metadata
+run-name: Publish metadata for PR #${{ inputs.pull_request }}
 
 on:
   workflow_dispatch:
     inputs:
       pull_request:
-        description: Pull request number
+        description: Upstream release pull request number
         required: true
         type: number
       head_sha:
-        description: Expected pull request head commit SHA
+        description: Exact tested pull request head SHA
         required: true
         type: string
-      reuse_uploaded_bottles:
-        description: Recover a failed metadata push using verified existing public bottles
-        default: false
-        type: boolean
 
 permissions: {}
 
-defaults:
-  run:
-    shell: bash -xeuo pipefail {0}
-
 jobs:
-  pr-pull:
+  publish:
+    if: github.repository == 'Kong/homebrew-kongctl' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
-      actions: read
-      attestations: write
       checks: read
       contents: write
-      id-token: write
-      issues: read
-      packages: write
       pull-requests: write
     steps:
-      - name: Validate release pull request
+      - name: Validate release metadata and merge only the tested head
+        shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HEAD_SHA: ${{ inputs.head_sha }}
           PULL_REQUEST: ${{ inputs.pull_request }}
         run: |
+          set -euo pipefail
+          [[ "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
           pr=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PULL_REQUEST")
-          actual_sha=$(jq -r '.head.sha' <<< "$pr")
-          base=$(jq -r '.base.ref' <<< "$pr")
-          branch=$(jq -r '.head.ref' <<< "$pr")
-          head_repo=$(jq -r '.head.repo.full_name' <<< "$pr")
-          state=$(jq -r '.state' <<< "$pr")
-
-          [[ "$actual_sha" == "$HEAD_SHA" ]]
-          [[ "$base" == "main" ]]
-          [[ "$branch" == release/kongctl-* ]]
-          [[ "$head_repo" == "$GITHUB_REPOSITORY" ]]
-          [[ "$state" == "open" ]]
-
-          changed_files=$(gh api --paginate \
-            "repos/$GITHUB_REPOSITORY/pulls/$PULL_REQUEST/files" \
-            --jq '.[].filename')
-          [[ "$changed_files" == "Formula/kongctl.rb" ]]
-
-          gh pr checks "$PULL_REQUEST" \
-            --repo "$GITHUB_REPOSITORY"
-
-      - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@3cdb78d0f62ad29dd32de765782654f4eedea607 # 2026.08.31.1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up git
-        id: git_setup
-        uses: Homebrew/actions/git-user-config@3cdb78d0f62ad29dd32de765782654f4eedea607 # 2026.08.31.1
-
-      - name: Use tap main for publication
-        run: |
-          # A workflow can be dispatched from a maintenance branch. Never
-          # include that branch's workflow changes in the published commits.
-          git fetch origin main
-          git checkout -B main FETCH_HEAD
-
-      - name: Pull and publish bottles
-        id: pull_bottles
-        env:
-          HEAD_SHA: ${{ inputs.head_sha }}
-          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_GITHUB_PACKAGES_USER: ${{ github.repository_owner }}
-          HOMEBREW_GIT_COMMITTER_EMAIL: ${{ steps.git_setup.outputs.email }}
-          HOMEBREW_GIT_COMMITTER_NAME: ${{ steps.git_setup.outputs.name }}
-          PULL_REQUEST: ${{ inputs.pull_request }}
-          REUSE_UPLOADED_BOTTLES: ${{ inputs.reuse_uploaded_bottles }}
-        run: |
-          args=(--debug --retain-bottle-dir --tap="$GITHUB_REPOSITORY" --head-sha="$HEAD_SHA")
-          if [[ "$REUSE_UPLOADED_BOTTLES" == true ]]; then
-            args+=(--no-upload)
+          jq -e --arg sha "$HEAD_SHA" --arg repo "$GITHUB_REPOSITORY" '
+            .head.sha == $sha and .head.repo.full_name == $repo and
+            .base.ref == "main" and .state == "open" and
+            (.head.ref | test("^release/kongctl-[0-9]+\\.[0-9]+\\.[0-9]+$"))
+          ' <<< "$pr" > /dev/null
+          files=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PULL_REQUEST/files" --jq '.[].filename')
+          [[ "$files" == Formula/kongctl.rb ]]
+          formula=$(gh api "repos/$GITHUB_REPOSITORY/contents/Formula/kongctl.rb?ref=$HEAD_SHA" --jq .content | base64 --decode)
+          # Reject obsolete source-building release PRs during the coordinated
+          # transition. All bottle publication now belongs to Kong/kongctl.
+          grep -Fqx '    bin.install "kongctl"' <<< "$formula"
+          grep -Fqx '  bottle do' <<< "$formula"
+          if grep -Fq 'depends_on "go"' <<< "$formula"; then
+            echo '::error::Upgrade Kong/kongctl release automation before publishing'
+            exit 1
           fi
-          brew pr-pull "${args[@]}" "$PULL_REQUEST"
-
-      - name: Verify existing public bottles and recover metadata
-        if: inputs.reuse_uploaded_bottles
-        env:
-          BOTTLE_DIR: ${{ steps.pull_bottles.outputs.bottle_path }}
-        run: |
-          shopt -s nullglob
-          metadata=("$BOTTLE_DIR"/*.bottle.json)
-          [[ ${#metadata[@]} -eq 3 ]]
-          expected_version=$(brew info --json=v2 --formula kong/kongctl/kongctl | jq -er '.formulae[0].versions.stable')
-          # Obtain an anonymous pull token; never use repository credentials
-          # to prove that ordinary users can download these bottles.
-          set +x
-          registry_token=$(curl --fail --silent --show-error --retry 3 --max-time 60 \
-            'https://ghcr.io/token?service=ghcr.io&scope=repository:kong/kongctl/kongctl:pull' | jq -er .token)
-          for json in "${metadata[@]}"; do
-            jq -e --arg version "$expected_version" '
-              keys == ["kong/kongctl/kongctl"] and
-              (.[] | .formula.pkg_version == $version and
-                .bottle.root_url == "https://ghcr.io/v2/kong/kongctl" and
-                (.bottle.tags | length == 1))
-            ' "$json" >/dev/null
-            digest=$(jq -er '.[] .bottle.tags[] .sha256' "$json")
-            filename=$(jq -er '.[] .bottle.tags[] .local_filename' "$json")
-            [[ "$digest" =~ ^[0-9a-f]{64}$ ]]
-            [[ "$filename" == "$(basename "$filename")" ]]
-            printf '%s  %s\n' "$digest" "$BOTTLE_DIR/$filename" | sha256sum --check
-            actual=$(curl --fail --silent --show-error --location --retry 3 --max-time 180 \
-              -H "Authorization: Bearer $registry_token" \
-              "https://ghcr.io/v2/kong/kongctl/kongctl/blobs/sha256:$digest" | sha256sum)
-            [[ "${actual%% *}" == "$digest" ]]
-          done
-          unset registry_token
-          set -x
-          jq -s -e '[.[] | .[] .bottle.tags | keys[]] | sort == ["arm64_sequoia", "sequoia", "x86_64_linux"]' "${metadata[@]}"
-          brew bottle --merge --write "${metadata[@]}"
-          brew audit --formula kong/kongctl/kongctl
-
-      - name: Generate build provenance
-        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
-        with:
-          subject-path: "${{ steps.pull_bottles.outputs.bottle_path }}/*.tar.gz"
-
-      - name: Push commits
-        uses: Homebrew/actions/git-try-push@3cdb78d0f62ad29dd32de765782654f4eedea607 # 2026.08.31.1
-        with:
-          # setup-homebrew already supplies Git authentication globally.
-          # Passing token here adds a second Authorization header and fails.
-          branch: main
-          tries: 3
+          checks=$(gh pr view "$PULL_REQUEST" --repo "$GITHUB_REPOSITORY" --json statusCheckRollup \
+            --jq '[.statusCheckRollup[] | select(.name | startswith("test-bot ("))] | length')
+          [[ "$checks" -ge 3 ]]
+          gh pr checks "$PULL_REQUEST" --repo "$GITHUB_REPOSITORY"
+          gh pr merge "$PULL_REQUEST" --repo "$GITHUB_REPOSITORY" \
+            --squash --match-head-commit "$HEAD_SHA" --delete-branch

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,9 @@ jobs:
           persist-credentials: false
 
       - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@cced187498280712e078aaba62dc13a3e9cd80bf
+        uses: Homebrew/actions/setup-homebrew@3cdb78d0f62ad29dd32de765782654f4eedea607 # 2026.08.31.1
+        with:
+          stable: true
 
       - name: Trust tap
         run: brew trust --tap kong/kongctl
@@ -51,7 +53,9 @@ jobs:
           persist-credentials: false
 
       - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@cced187498280712e078aaba62dc13a3e9cd80bf
+        uses: Homebrew/actions/setup-homebrew@3cdb78d0f62ad29dd32de765782654f4eedea607 # 2026.08.31.1
+        with:
+          stable: true
 
       - name: Trust tap
         run: brew trust --tap kong/kongctl
@@ -62,9 +66,20 @@ jobs:
           set -euo pipefail
           brew install --cask kong/kongctl/kongctl
           brew uninstall --cask kong/kongctl/kongctl
+          while IFS= read -r formula; do
+            case "$formula" in
+              go|go@*) brew uninstall --formula --force --ignore-dependencies "$formula" ;;
+            esac
+          done < <(brew list --formula)
+          # Homebrew calls this "from source", but our recipe only installs
+          # the upstream release ZIP. This tests the non-bottle fallback.
           brew install --formula --build-from-source kong/kongctl/kongctl
           brew test kong/kongctl/kongctl
           kongctl version --full
+          if brew list --formula | grep -E '^go(@.*)?$'; then
+            echo '::error::Prebuilt fallback unexpectedly installed Go'
+            exit 1
+          fi
 
   upgrade:
     runs-on: ubuntu-latest
@@ -76,7 +91,9 @@ jobs:
           persist-credentials: false
 
       - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@cced187498280712e078aaba62dc13a3e9cd80bf
+        uses: Homebrew/actions/setup-homebrew@3cdb78d0f62ad29dd32de765782654f4eedea607 # 2026.08.31.1
+        with:
+          stable: true
 
       - name: Trust tap
         run: brew trust --tap kong/kongctl
@@ -93,8 +110,8 @@ jobs:
           current_formula="$RUNNER_TEMP/kongctl-current.rb"
           cp Formula/kongctl.rb "$current_formula"
           git show HEAD^:Formula/kongctl.rb > Formula/kongctl.rb
-          brew install --formula --build-from-source kong/kongctl/kongctl
+          brew install --formula --force-bottle kong/kongctl/kongctl
           cp "$current_formula" Formula/kongctl.rb
-          brew upgrade --formula --build-from-source kong/kongctl/kongctl
+          brew upgrade --formula kong/kongctl/kongctl
           brew test kong/kongctl/kongctl
           kongctl version --full

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,144 +1,47 @@
-name: brew test-bot
+name: Homebrew bottle installation
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
   pull_request:
 
-permissions: {}
-
-defaults:
-  run:
-    shell: bash -xeuo pipefail {0}
+permissions:
+  contents: read
 
 jobs:
+  # Preserve the existing check names used by kongctl release automation.
+  # These jobs consume published bottles; they no longer build or upload them.
   test-bot:
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, macos-15, macos-15-intel]
     runs-on: ${{ matrix.os }}
-    permissions:
-      actions: read
-      checks: read
-      contents: read
-      packages: read
-      pull-requests: read
+    timeout-minutes: 15
     steps:
-      - name: Set up Homebrew
-        id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@3cdb78d0f62ad29dd32de765782654f4eedea607 # 2026.08.31.1
+      - uses: Homebrew/actions/setup-homebrew@3cdb78d0f62ad29dd32de765782654f4eedea607 # 2026.08.31.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Cache Homebrew Bundler RubyGems
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ${{ steps.set-up-homebrew.outputs.gems-path }}
-          key: ${{ matrix.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
-          restore-keys: ${{ matrix.os }}-rubygems-
-
-      - run: brew test-bot --only-cleanup-before
-
-      - run: brew test-bot --only-setup
-
-      # Homebrew's Intel ShellCheck dependency needs GMP from source, whose
-      # download servers are unreliable from GitHub runners. Keep this version
-      # aligned with homebrew/core so brew style accepts the executable on PATH.
-      - name: Install ShellCheck binary on Intel macOS
-        if: matrix.os == 'macos-15-intel'
-        run: |
-          shellcheck_dir=$(mktemp -d "$RUNNER_TEMP/shellcheck.XXXXXX")
-          archive="$shellcheck_dir/shellcheck.tar.gz"
-          curl --fail --location --retry 3 --connect-timeout 15 --max-time 120 \
-            --output "$archive" \
-            https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.darwin.x86_64.tar.gz
-          printf '%s  %s\n' \
-            c2c15e08df0e8fbc374c335b230a7ee958c313fa5714817a59aa59f1aa594f51 \
-            "$archive" | shasum -a 256 --check
-          tar -xzf "$archive" -C "$shellcheck_dir"
-          "$shellcheck_dir/shellcheck-v0.11.0/shellcheck" --version
-          # test-bot rebuilds PATH for nested brew commands. Its explicit
-          # prefix/bin survives that reset, unlike a GITHUB_PATH addition.
-          shellcheck_bin="$(brew --prefix)/bin/shellcheck"
-          ln -s "$shellcheck_dir/shellcheck-v0.11.0/shellcheck" "$shellcheck_bin"
-          "$shellcheck_bin" --version
-
-      # Installing actionlint through Homebrew pulls in its ShellCheck formula
-      # dependency even when an external ShellCheck binary is already on PATH.
-      - name: Install actionlint binary on Intel macOS
-        if: matrix.os == 'macos-15-intel'
-        run: |
-          actionlint_dir=$(mktemp -d "$RUNNER_TEMP/actionlint.XXXXXX")
-          archive="$actionlint_dir/actionlint.tar.gz"
-          curl --fail --location --retry 3 --connect-timeout 15 --max-time 120 \
-            --output "$archive" \
-            https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_darwin_amd64.tar.gz
-          printf '%s  %s\n' \
-            5b44c3bc2255115c9b69e30efc0fecdf498fdb63c5d58e17084fd5f16324c644 \
-            "$archive" | shasum -a 256 --check
-          tar -xzf "$archive" -C "$actionlint_dir" actionlint
-          actionlint_bin="$(brew --prefix)/bin/actionlint"
-          ln -s "$actionlint_dir/actionlint" "$actionlint_bin"
-          "$actionlint_bin" -version
-
-      - run: brew test-bot --only-tap-syntax --verbose
-        timeout-minutes: 10
-
-      - name: Authorize GitHub Packages
-        id: packages
-        if: github.event_name == 'pull_request'
+          stable: true
+      - name: Install the formula's public bottle without Go
+        shell: bash
         env:
-          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_NO_AUTO_UPDATE: 1
         run: |
-          token=$(printf '%s' "$TOKEN" | base64 | tr -d '\n')
-          echo "::add-mask::$token"
-          echo "token=$token" >> "$GITHUB_OUTPUT"
-
-      - name: Test formula and build bottle
-        id: bottles
-        if: github.event_name == 'pull_request'
-        env:
-          HOMEBREW_DOCKER_REGISTRY_TOKEN: ${{ steps.packages.outputs.token }}
-        run: >-
-          brew test-bot --only-formulae
-          --root-url=https://ghcr.io/v2/kong/kongctl
-
-      # test-bot skips Intel builds when Go has no compatible Homebrew bottle.
-      # The build dependency can still be installed from source by Homebrew.
-      - name: Build and test Intel bottle with source dependencies
-        if: >-
-          github.event_name == 'pull_request' && matrix.os == 'macos-15-intel' &&
-          steps.bottles.outputs.skipped_or_failed_formulae == 'kong/kongctl/kongctl'
-        run: |
-          brew install --formula --only-dependencies --build-from-source kong/kongctl/kongctl
-          brew install --formula --build-bottle kong/kongctl/kongctl
-          brew bottle --json --root-url=https://ghcr.io/v2/kong/kongctl kong/kongctl/kongctl
-          shopt -s nullglob
-          bottles=(kongctl--*.bottle*.tar.gz)
-          [[ ${#bottles[@]} -eq 1 ]]
-          brew uninstall --formula kong/kongctl/kongctl
-          # Like test-bot, enable developer mode for this local archive install.
-          HOMEBREW_DEVELOPER=1 brew install --formula "./${bottles[0]}"
-          brew linkage --test kong/kongctl/kongctl
+          set -euo pipefail
+          brew trust --tap kong/kongctl
+          while IFS= read -r formula; do
+            case "$formula" in
+              go|go@*) brew uninstall --formula --force --ignore-dependencies "$formula" ;;
+            esac
+          done < <(brew list --formula)
+          unset HOMEBREW_GITHUB_API_TOKEN HOMEBREW_GITHUB_PACKAGES_TOKEN
+          unset HOMEBREW_DOCKER_REGISTRY_TOKEN GITHUB_TOKEN GH_TOKEN
+          brew install --formula --force-bottle kong/kongctl/kongctl
+          brew info --json=v2 --formula kong/kongctl/kongctl |
+            jq -e '.formulae[0].installed | length == 1 and .[0].poured_from_bottle == true'
           brew test kong/kongctl/kongctl
           kongctl version --full
-
-      - name: Require bottle artifacts for changed formula
-        if: >-
-          github.event_name == 'pull_request' &&
-          contains(steps.bottles.outputs.testing_formulae, 'kong/kongctl/kongctl')
-        run: |
-          shopt -s nullglob
-          bottles=(kongctl--*.bottle*.tar.gz)
-          metadata=(kongctl--*.bottle.json)
-          [[ ${#bottles[@]} -eq 1 ]]
-          [[ ${#metadata[@]} -eq 1 ]]
-
-      - name: Upload bottles as artifact
-        if: always() && github.event_name == 'pull_request'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: bottles_${{ matrix.os }}
-          path: '*.bottle.*'
+          if brew list --formula | grep -E '^go(@.*)?$'; then
+            echo '::error::Bottle installation unexpectedly installed Go'
+            exit 1
+          fi

--- a/Formula/kongctl.rb
+++ b/Formula/kongctl.rb
@@ -1,8 +1,7 @@
 class Kongctl < Formula
   desc "Developer CLI for Kong"
   homepage "https://github.com/Kong/kongctl"
-  url "https://github.com/Kong/kongctl/archive/refs/tags/v1.15.0.tar.gz"
-  sha256 "a86c09baa409fbe220c29a6f52f4fb98d473e4b1da1d4b935ccdc6cd766415a1"
+  version "1.15.0"
   license "Apache-2.0"
 
   bottle do
@@ -13,23 +12,34 @@ class Kongctl < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "63b3a8ca14d79de6ed02f585c3661b22fb29f211be15db24bfcf59ab7ae1e94c"
   end
 
-  depends_on "go" => :build
+  on_macos do
+    on_arm do
+      url "https://github.com/Kong/kongctl/releases/download/v1.15.0/kongctl_darwin_arm64.zip"
+      sha256 "84bee62d03a977c55312cb4a599a93cc80541ba58e3cc727e6333b55ee4f5e03"
+    end
+    on_intel do
+      url "https://github.com/Kong/kongctl/releases/download/v1.15.0/kongctl_darwin_amd64.zip"
+      sha256 "59237d32de65550e9e6f54bcfbc20a5cd2812ca4328bc244cf741de1f91a8667"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "https://github.com/Kong/kongctl/releases/download/v1.15.0/kongctl_linux_arm64.zip"
+      sha256 "3d37f08d8ecb02b9128c2f3abb265781efb0a3685b6c20bf4d515547055c04bc"
+    end
+    on_intel do
+      url "https://github.com/Kong/kongctl/releases/download/v1.15.0/kongctl_linux_amd64.zip"
+      sha256 "5fcc9c53ad8577b3f0dc2235b3c29c638381e308e5b23f47ca338c1872f8577c"
+    end
+  end
 
   def install
-    ldflags = %W[
-      -X main.version=#{version}
-      -X main.commit=86e156e0
-      -X main.date=2026-09-02T16:47:12.720631851Z
-    ]
-
-    ENV["CGO_ENABLED"] = "0"
-    system "go", "build", *std_go_args(ldflags:)
+    bin.install "kongctl"
   end
 
   test do
-    output = shell_output("#{bin}/kongctl version --full")
-    assert_match version.to_s, output
-    assert_match "86e156e0", output
+    assert_match version.to_s, shell_output("#{bin}/kongctl version --full")
     assert_match "__kongctl_debug", shell_output("#{bin}/kongctl completion bash")
     assert_match "#compdef kongctl", shell_output("#{bin}/kongctl completion zsh")
   end

--- a/Formula/kongctl.rb
+++ b/Formula/kongctl.rb
@@ -1,7 +1,6 @@
 class Kongctl < Formula
   desc "Developer CLI for Kong"
   homepage "https://github.com/Kong/kongctl"
-  version "1.15.0"
   license "Apache-2.0"
 
   bottle do

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,36 @@
+# Release ownership
+
+This tap publishes package definitions, not executables. `Kong/kongctl` owns
+compilation, Apple signing/notarization, bottle packaging, registry publication,
+and verification of the final downloads. Apple credentials remain only there.
+
+- The cask installs upstream release ZIPs and keeps its direct-main update path.
+- The formula installs upstream binaries without a Go dependency. Matching
+  bottles come from the public `ghcr.io/kong/kongctl/kongctl` package. When a
+  bottle is unavailable, the formula installs the platform's upstream ZIP.
+- `brew install --formula kong/kongctl/kongctl` and the existing cask command
+  remain unchanged. Cask-to-formula switching still requires uninstalling the
+  cask first because both expose the same `kongctl` command.
+- Existing 1.15.0 bottle URLs/checksums and the cask remain unchanged. This
+  migration does not retrofit Apple signatures onto old releases or bottles.
+
+## Automated metadata publication
+
+After publishing and verifying all three bottles, the upstream release opens
+a formula-only `release/kongctl-VERSION` PR. Tap CI checks installation from
+the public bottles, prebuilt ZIP fallback, cask migration, and formula upgrade.
+The upstream workflow waits for these checks and dispatches `publish.yml`
+with the exact tested head SHA. That workflow validates and merges only the
+formula PR. It does not build bottles, upload packages, or access signing keys.
+No routine manual PR merge is required; failed checks leave a visible open PR.
+
+`publish.yml` intentionally rejects the old source-building release PRs.
+Coordinate this tap change with the upstream release-workflow change before
+starting another release. Merge the tap change first, then the upstream PR;
+do not release during the interval. Installation of existing versions remains
+available throughout.
+
+The old `brew pr-pull` publisher and bottle CI artifacts are retired. Retry a
+failed upstream publisher using artifacts from the original upstream run.
+Never replace already-published bottle bytes to make a retry pass. Registry
+access, attestations, and partial-publication investigation belong upstream.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -29,6 +29,8 @@ Coordinate this tap change with the upstream release-workflow change before
 starting another release. Merge the tap change first, then the upstream PR;
 do not release during the interval. Installation of existing versions remains
 available throughout.
+The `.github/kongctl-release-protocol.json` marker lets the new upstream
+workflow check compatibility before creating a release tag.
 
 The old `brew pr-pull` publisher and bottle CI artifacts are retired. Retry a
 failed upstream publisher using artifacts from the original upstream run.


### PR DESCRIPTION
## Summary

Realign the tap as a metadata publisher; compilation, Apple signing,
notarization, bottle packaging, GHCR publication, and final artifact checks
belong in Kong/kongctl. Apple credentials stay only in that repository.

- Change the formula's fallback from Go compilation to upstream release ZIPs.
- Preserve all existing 1.15.0 bottle checksums, rebuild number, and registry URL.
- Leave `Casks/kongctl.rb` unchanged; preserve its direct-main release updates.
- Replace tap bottle-building CI with public bottle installation checks, keeping
  the existing three `test-bot` check names for upstream automation.
- Retain fresh fallback installation, cask migration, audit and upgrade checks.
- Replace `brew pr-pull` with a guarded metadata-only PR merger. It requires
  a same-repository release branch, formula-only diff, exact tested SHA,
  published bottle metadata and passing CI. It has no package-write permission.
- Advertise the publication protocol so upstream checks compatibility before
  creating a release tag.

## Coordination

Companion: https://github.com/Kong/kongctl/pull/2078

Prepared for coordinated manual merge. Merge this tap PR first, then the
upstream release changes, with no release dispatched between the merges.
Old source-formula release PRs are deliberately rejected by the new publisher.
Existing installations continue to work; no existing assets are replaced or
retroactively claimed to be Apple signed.

Upstream's final cleanup removes temporary validation triggers. Its full
signing, native installation and three-platform bottle validation is green:
https://github.com/Kong/kongctl/actions/runs/34003977811
The maintainer's clean-Mac browser acceptance remains separate from CI; its
procedure is in upstream docs/contributor/apple-signing-mac-test.md. No
additional reviewer approval is being requested; the maintainer will merge.

Routine release PRs remain automatically merged after checks; no manual merge
is normally needed. See RELEASING.md for ownership and recovery boundaries.

## Validation

- Ruby syntax, actionlint/ShellCheck and `git diff --check`: passed locally.
- Cask file and existing bottle block preserved byte-for-byte.
- All current checks at 30856c4 are green: three native public-bottle installs,
  three fallback/cask-migration installs, audit, upgrade and CodeQL.
- Upstream's new bottle packaging, native verification and metadata merge pass
  on all three platforms: https://github.com/Kong/kongctl/actions/runs/34003058084
- No production release or registry writes performed.
